### PR TITLE
fixing failed tests, several optimizations to unit and integration tests

### DIFF
--- a/tests/unit/core/test_client_comments.py
+++ b/tests/unit/core/test_client_comments.py
@@ -9,16 +9,16 @@ from crawl4weibo.models.comment import Comment
 
 @pytest.mark.unit
 class TestWeiboClientComments:
-    def test_client_has_comment_methods(self):
+    def test_client_has_comment_methods(self, client_no_rate_limit):
         """Test that comment methods exist"""
-        client = WeiboClient()
+        client = client_no_rate_limit
         assert hasattr(client, "get_comments")
         assert hasattr(client, "get_all_comments")
         assert callable(getattr(client, "get_comments"))
         assert callable(getattr(client, "get_all_comments"))
 
     @responses.activate
-    def test_get_comments_single_page(self):
+    def test_get_comments_single_page(self, client_no_rate_limit):
         """Test getting comments for a single page"""
         weibo_api_url = "https://m.weibo.cn/api/comments/show"
 
@@ -75,7 +75,7 @@ class TestWeiboClientComments:
             status=200,
         )
 
-        client = WeiboClient()
+        client = client_no_rate_limit
         comments, pagination = client.get_comments("4876256422135140", page=1)
 
         assert len(comments) == 2
@@ -96,7 +96,7 @@ class TestWeiboClientComments:
         assert "宝藏博主" in comments[1].text
 
     @responses.activate
-    def test_get_comments_with_image(self):
+    def test_get_comments_with_image(self, client_no_rate_limit):
         """Test getting comment with image attachment"""
         weibo_api_url = "https://m.weibo.cn/api/comments/show"
 
@@ -135,7 +135,7 @@ class TestWeiboClientComments:
             status=200,
         )
 
-        client = WeiboClient()
+        client = client_no_rate_limit
         comments, pagination = client.get_comments("123456")
 
         assert len(comments) == 1
@@ -143,7 +143,7 @@ class TestWeiboClientComments:
         assert comments[0].user_verified is True
 
     @responses.activate
-    def test_get_comments_empty_response(self):
+    def test_get_comments_empty_response(self, client_no_rate_limit):
         """Test getting comments when no comments exist"""
         weibo_api_url = "https://m.weibo.cn/api/comments/show"
 
@@ -154,7 +154,7 @@ class TestWeiboClientComments:
             status=200,
         )
 
-        client = WeiboClient()
+        client = client_no_rate_limit
         comments, pagination = client.get_comments("123456")
 
         assert len(comments) == 0
@@ -162,7 +162,7 @@ class TestWeiboClientComments:
         assert pagination["max"] == 0
 
     @responses.activate
-    def test_get_all_comments_multiple_pages(self):
+    def test_get_all_comments_multiple_pages(self, client_no_rate_limit):
         """Test getting all comments with pagination"""
         weibo_api_url = "https://m.weibo.cn/api/comments/show"
 
@@ -230,7 +230,7 @@ class TestWeiboClientComments:
             status=200,
         )
 
-        client = WeiboClient()
+        client = client_no_rate_limit
         all_comments = client.get_all_comments("123456")
 
         assert len(all_comments) == 2
@@ -240,7 +240,7 @@ class TestWeiboClientComments:
         assert all_comments[1].liked is True
 
     @responses.activate
-    def test_get_all_comments_with_max_pages(self):
+    def test_get_all_comments_with_max_pages(self, client_no_rate_limit):
         """Test getting comments with max_pages limit"""
         weibo_api_url = "https://m.weibo.cn/api/comments/show"
 
@@ -281,7 +281,7 @@ class TestWeiboClientComments:
             status=200,
         )
 
-        client = WeiboClient()
+        client = client_no_rate_limit
         all_comments = client.get_all_comments("123456", max_pages=1)
 
         # Should only fetch 1 page even though max=10
@@ -290,7 +290,7 @@ class TestWeiboClientComments:
         assert len([c for c in responses.calls if "comments" in c.request.url]) == 1
 
     @responses.activate
-    def test_comment_model_to_dict(self):
+    def test_comment_model_to_dict(self, client_no_rate_limit):
         """Test Comment model to_dict method"""
         weibo_api_url = "https://m.weibo.cn/api/comments/show"
 
@@ -327,7 +327,7 @@ class TestWeiboClientComments:
             status=200,
         )
 
-        client = WeiboClient()
+        client = client_no_rate_limit
         comments, _ = client.get_comments("123456")
 
         comment_dict = comments[0].to_dict()

--- a/tests/unit/core/test_client_proxy_integration.py
+++ b/tests/unit/core/test_client_proxy_integration.py
@@ -14,7 +14,7 @@ class TestProxyElimination:
     """Tests for proxy elimination on 432 errors"""
 
     @responses.activate
-    def test_proxy_removed_on_432_pooling_mode(self):
+    def test_proxy_removed_on_432_pooling_mode(self, client_no_rate_limit_with_proxy):
         """Test that proxy is removed from pool when it returns 432 in pooling mode"""
         proxy_api_url = "http://api.proxy.com/get"
         weibo_api_url = "https://m.weibo.cn/api/container/getIndex"
@@ -54,7 +54,7 @@ class TestProxyElimination:
         )
 
         proxy_config = ProxyPoolConfig(proxy_api_url=proxy_api_url, pool_size=5)
-        client = WeiboClient(proxy_config=proxy_config)
+        client = client_no_rate_limit_with_proxy
 
         client.add_proxy("http://10.20.30.40:8080")
         initial_pool_size = client.get_proxy_pool_size()
@@ -67,7 +67,7 @@ class TestProxyElimination:
         assert user.screen_name == "TestUser"
 
     @responses.activate
-    def test_proxy_not_removed_on_200_success(self):
+    def test_proxy_not_removed_on_200_success(self, client_no_rate_limit):
         """Test that proxy is NOT removed when request succeeds with 200"""
         weibo_api_url = "https://m.weibo.cn/api/container/getIndex"
 
@@ -87,7 +87,7 @@ class TestProxyElimination:
             status=200,
         )
 
-        client = WeiboClient()
+        client = client_no_rate_limit
         client.add_proxy("http://1.2.3.4:8080")
         assert client.get_proxy_pool_size() == 1
 
@@ -136,19 +136,30 @@ class TestProxyElimination:
             status=200,
         )
 
-        proxy_config = ProxyPoolConfig(proxy_api_url=proxy_api_url, use_once_proxy=True)
-        client = WeiboClient(proxy_config=proxy_config)
+        # Create client with once-proxy mode (not using fixture)
+        from crawl4weibo.utils.rate_limit import RateLimitConfig
 
-        assert client.get_proxy_pool_size() == 0
+        with patch("crawl4weibo.core.client.CookieFetcher"):
+            proxy_config = ProxyPoolConfig(proxy_api_url=proxy_api_url, use_once_proxy=True)
+            rate_config = RateLimitConfig(disable_delay=True)
+            client = WeiboClient(
+                rate_limit_config=rate_config,
+                proxy_config=proxy_config,
+                auto_fetch_cookies=False,
+            )
 
-        user = client.get_user_by_uid("2656274875")
+            # In once mode, proxies are never pooled, so pool size should be 0
+            assert client.get_proxy_pool_size() == 0
 
-        assert user is not None
-        assert user.screen_name == "TestUser"
-        assert client.get_proxy_pool_size() == 0
+            user = client.get_user_by_uid("2656274875")
+
+            assert user is not None
+            assert user.screen_name == "TestUser"
+            # Pool size should still be 0 after requests
+            assert client.get_proxy_pool_size() == 0
 
     @responses.activate
-    def test_multiple_432_removes_multiple_proxies(self):
+    def test_multiple_432_removes_multiple_proxies(self, client_no_rate_limit):
         """Test that multiple 432 errors remove multiple proxies"""
         weibo_api_url = "https://m.weibo.cn/api/container/getIndex"
 
@@ -171,7 +182,7 @@ class TestProxyElimination:
             status=200,
         )
 
-        client = WeiboClient()
+        client = client_no_rate_limit
         client.proxy_pool.config.fetch_strategy = "round_robin"
         client.add_proxy("http://1.2.3.4:8080")
         client.add_proxy("http://5.6.7.8:9090")

--- a/tests/unit/core/test_client_search.py
+++ b/tests/unit/core/test_client_search.py
@@ -15,7 +15,7 @@ class TestSearchPosts:
     """Test search_posts method with pagination info"""
 
     @responses.activate
-    def test_search_posts_returns_pagination_info(self):
+    def test_search_posts_returns_pagination_info(self, client_no_rate_limit):
         """Test that search_posts returns pagination info"""
         weibo_api_url = "https://m.weibo.cn/api/container/getIndex"
 
@@ -48,7 +48,7 @@ class TestSearchPosts:
             status=200,
         )
 
-        client = WeiboClient()
+        client = client_no_rate_limit
         posts, pagination = client.search_posts("Python", page=1)
 
         assert len(posts) == 1
@@ -57,7 +57,7 @@ class TestSearchPosts:
         assert pagination["has_more"] is True
 
     @responses.activate
-    def test_search_posts_last_page_detection(self):
+    def test_search_posts_last_page_detection(self, client_no_rate_limit):
         """Test that last page is detected when cardlistInfo.page is None"""
         weibo_api_url = "https://m.weibo.cn/api/container/getIndex"
 
@@ -90,7 +90,7 @@ class TestSearchPosts:
             status=200,
         )
 
-        client = WeiboClient()
+        client = client_no_rate_limit
         posts, pagination = client.search_posts("Python", page=1)
 
         assert len(posts) == 1
@@ -200,7 +200,6 @@ class TestSearchPostsByCount:
         responses.add(responses.GET, weibo_api_url, json=mock_page1, status=200)
         responses.add(responses.GET, weibo_api_url, json=mock_page2, status=200)
 
-        client = WeiboClient()
         posts = client_no_rate_limit.search_posts_by_count("Python", count=100)
 
         # Should stop at page 2 (15 posts total)
@@ -400,7 +399,6 @@ class TestSearchAllPosts:
             }
             responses.add(responses.GET, weibo_api_url, json=mock_data, status=200)
 
-        client = WeiboClient()
         posts = client_no_rate_limit.search_all_posts("Python")
 
         # Should fetch all 30 posts from 3 pages
@@ -439,7 +437,6 @@ class TestSearchAllPosts:
         for _ in range(10):
             responses.add(responses.GET, weibo_api_url, json=mock_data, status=200)
 
-        client = WeiboClient()
         posts = client_no_rate_limit.search_all_posts("Python", max_pages=2)
 
         # Should fetch only 2 pages = 20 posts
@@ -455,7 +452,6 @@ class TestSearchAllPosts:
 
         responses.add(responses.GET, weibo_api_url, json=mock_data, status=200)
 
-        client = WeiboClient()
         posts = client_no_rate_limit.search_all_posts("NonExistentTopic")
 
         assert len(posts) == 0

--- a/tests/unit/utils/test_cookie_fetcher.py
+++ b/tests/unit/utils/test_cookie_fetcher.py
@@ -352,6 +352,8 @@ class TestAsyncBrowserSupport:
                 pass
 
         # Patch the import and execute
+        # Save original __import__ to avoid recursion
+        original_import = __import__
         with patch("builtins.__import__") as mock_import:
 
             def custom_import(name, *args, **kwargs):
@@ -359,7 +361,7 @@ class TestAsyncBrowserSupport:
                     module = Mock()
                     module.async_playwright = lambda: MockAsyncPlaywright()
                     return module
-                return __import__(name, *args, **kwargs)
+                return original_import(name, *args, **kwargs)
 
             mock_import.side_effect = custom_import
 
@@ -387,12 +389,14 @@ class TestAsyncBrowserSupport:
         fetcher = CookieFetcher(use_browser=True)
 
         # Mock the import to raise ImportError
+        # Save original __import__ to avoid recursion
+        original_import = __import__
         with patch("builtins.__import__") as mock_import:
 
             def custom_import(name, *args, **kwargs):
                 if name == "playwright.async_api":
                     raise ImportError("No module named 'playwright'")
-                return __import__(name, *args, **kwargs)
+                return original_import(name, *args, **kwargs)
 
             mock_import.side_effect = custom_import
 


### PR DESCRIPTION
Greetings [Kritoooo](https://github.com/Kritoooo)

Before: 
uv run pytest --durations=5 -v                   --->      1 failed, 226 passed, 2 skipped in 408.40s (0:06:48)
uv run pytest tests/unit --durations=5 -v   --->      1 failed, 220 passed in 271.58s (0:04:31)

On this PR:
uv run pytest --durations=5 -v                   --->      229 passed in 189.77s (0:03:09)
uv run pytest tests/unit --durations=5 -v   --->      221 passed in 66.80s (0:01:06)

fixed infinite recursion on imports, and optimized rate limiting

Recommendations
Continue using rate limit optimization pattern for all future test fixtures
Document API return types in docstrings
Consider adding type hints to catch tuple-unpacking mismatches at development time