### PR TITLE
fix: add workflow permissions

### DIFF
--- a/.github/workflows/availability.yml
+++ b/.github/workflows/availability.yml
@@ -6,6 +6,9 @@ on:
     - cron: "30 2 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: daily-availability
   cancel-in-progress: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-22.04

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   code-quality:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
## Summary
- add explicit minimal `contents: read` permissions to CI, code-quality, and availability workflows to satisfy CodeQL checks

## Testing
- not run (workflow-only change)
