### PR TITLE
docs: add Codex MCP config examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,85 +210,12 @@ posts = client.get_user_posts("2656274875", page=1)  # Uses proxy
 
 ## MCP Server (for agents)
 
-You can run crawl4weibo as an MCP server so LLM agents can call its tools directly.
+MCP setup details moved to dedicated docs:
+- `docs/MCP.md` (English)
+- `docs/MCP_zh.md` (中文)
 
-> MCP server support requires Python 3.10+.
-> On Python 3.9, the `crawl4weibo[mcp]` extra is unavailable
-> regardless of installer (`uv`, `uvx`, `pip`).
-
-Install with MCP extra (recommended with uv):
-
-```bash
-uv tool install "crawl4weibo[mcp]"
-uv tool run --from "crawl4weibo[mcp]" python -m playwright install chromium
-```
-
-Alternative (pip):
-
-```bash
-pip install "crawl4weibo[mcp]"
-python -m playwright install chromium
-```
-
-Start server (stdio transport):
-
-```bash
-crawl4weibo-mcp
-```
-
-If the command is not on your `PATH`:
-
-```bash
-uv tool run --from "crawl4weibo[mcp]" crawl4weibo-mcp
-```
-
-Available tools:
-- `get_user_by_uid`
-- `get_user_posts`
-- `get_post_by_bid`
-- `search_users`
-- `search_posts`
-- `get_comments`
-- `get_all_comments`
-
-Response detail levels:
-- By default, MCP tools return compact payloads (`detail_level="compact"`) to save context and tokens.
-- Use `detail_level="full"` when you need full model fields (closer to raw API shape).
-
-CLI options:
-- `--cookie`: pass raw cookie string directly.
-  Auto-fetch only applies when `--auto-fetch-cookies` is enabled.
-- `--disable-browser-cookies`: use requests-based cookie mode.
-- `--auto-fetch-cookies`: auto-fetch cookies on startup (disabled by default).
-
-Quick MCP config example (Claude Desktop):
-
-```json
-{
-  "mcpServers": {
-    "crawl4weibo": {
-      "command": "crawl4weibo-mcp",
-      "args": ["--auto-fetch-cookies"]
-    }
-  }
-}
-```
-
-Codex CLI config (stdio):
-
-```bash
-# Recommended: persistent tool install via uv
-uv tool install "crawl4weibo[mcp]"
-uv tool run --from "crawl4weibo[mcp]" python -m playwright install chromium
-codex mcp add crawl4weibo -- crawl4weibo-mcp --auto-fetch-cookies
-```
-
-```bash
-# Optional: uvx (ephemeral) + prewarm Playwright to avoid handshake timeouts
-uvx --from "crawl4weibo[mcp]" python -m playwright install chromium
-codex mcp add crawl4weibo -- uvx --from "crawl4weibo[mcp]" \
-  crawl4weibo-mcp --auto-fetch-cookies
-```
+These docs include requirements, installation, startup, tool list,
+response detail levels, and Codex/Claude configuration examples.
 
 ## Development & Testing
 ```bash

--- a/README_zh.md
+++ b/README_zh.md
@@ -208,85 +208,12 @@ posts = client.get_user_posts("2656274875", page=1)  # 使用代理
 
 ## MCP 服务器（供 Agent 调用）
 
-可将 crawl4weibo 作为 MCP 服务运行，供 LLM Agent 直接调用。
+MCP 相关说明已迁移至独立文档：
+- `docs/MCP_zh.md`（中文）
+- `docs/MCP.md` (English)
 
-> MCP 服务端功能要求 Python 3.10+。
-> 在 Python 3.9 下，无论使用 `uv`、`uvx` 还是 `pip`，
-> `crawl4weibo[mcp]` 额外依赖都不会生效。
-
-安装（含 MCP 可选依赖，推荐 uv）：
-
-```bash
-uv tool install "crawl4weibo[mcp]"
-uv tool run --from "crawl4weibo[mcp]" python -m playwright install chromium
-```
-
-备选（pip）：
-
-```bash
-pip install "crawl4weibo[mcp]"
-python -m playwright install chromium
-```
-
-启动服务（stdio 传输）：
-
-```bash
-crawl4weibo-mcp
-```
-
-若命令不在 `PATH` 中：
-
-```bash
-uv tool run --from "crawl4weibo[mcp]" crawl4weibo-mcp
-```
-
-提供的工具：
-- `get_user_by_uid`
-- `get_user_posts`
-- `get_post_by_bid`
-- `search_users`
-- `search_posts`
-- `get_comments`
-- `get_all_comments`
-
-响应详细级别：
-- MCP 工具默认返回精简结果（`detail_level="compact"`），更节省上下文和 token。
-- 如需完整字段（更接近原始 API 结构），可传 `detail_level="full"`。
-
-CLI 参数：
-- `--cookie`：直接传入原始 cookie 字符串。
-  仅在启用 `--auto-fetch-cookies` 时才会自动抓取 cookie。
-- `--disable-browser-cookies`：禁用 Playwright，改用 requests 方式。
-- `--auto-fetch-cookies`：启动时自动抓取 cookie（默认关闭）。
-
-MCP 配置示例（Claude Desktop）：
-
-```json
-{
-  "mcpServers": {
-    "crawl4weibo": {
-      "command": "crawl4weibo-mcp",
-      "args": ["--auto-fetch-cookies"]
-    }
-  }
-}
-```
-
-Codex CLI 配置（stdio）：
-
-```bash
-# 推荐：使用 uv 持久安装工具
-uv tool install "crawl4weibo[mcp]"
-uv tool run --from "crawl4weibo[mcp]" python -m playwright install chromium
-codex mcp add crawl4weibo -- crawl4weibo-mcp --auto-fetch-cookies
-```
-
-```bash
-# 可选：使用 uvx（临时环境），先预热 Playwright 避免握手超时
-uvx --from "crawl4weibo[mcp]" python -m playwright install chromium
-codex mcp add crawl4weibo -- uvx --from "crawl4weibo[mcp]" \
-  crawl4weibo-mcp --auto-fetch-cookies
-```
+文档包含环境要求、安装与启动方式、工具列表、
+响应详细级别，以及 Codex/Claude 的配置示例。
 
 ## 开发与测试
 ```bash

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -1,0 +1,88 @@
+# MCP Server (for agents)
+
+You can run crawl4weibo as an MCP server so LLM agents can call its tools directly.
+
+## Requirements
+
+- Python 3.10+
+- On Python 3.9, the `crawl4weibo[mcp]` extra is unavailable regardless of installer (`uv`, `uvx`, `pip`).
+
+## Install
+
+Recommended (`uv`):
+
+```bash
+uv tool install "crawl4weibo[mcp]"
+uv tool run --from "crawl4weibo[mcp]" python -m playwright install chromium
+```
+
+Alternative (`pip`):
+
+```bash
+pip install "crawl4weibo[mcp]"
+python -m playwright install chromium
+```
+
+## Start Server (stdio)
+
+```bash
+crawl4weibo-mcp
+```
+
+If the command is not on your `PATH`:
+
+```bash
+uv tool run --from "crawl4weibo[mcp]" crawl4weibo-mcp
+```
+
+## Available Tools
+
+- `get_user_by_uid`
+- `get_user_posts`
+- `get_post_by_bid`
+- `search_users`
+- `search_posts`
+- `get_comments`
+- `get_all_comments`
+
+## Response Detail Levels
+
+- Default: `detail_level="compact"` for smaller payloads and lower token usage.
+- Full: `detail_level="full"` for full model fields (closer to raw API shape).
+
+## CLI Options
+
+- `--cookie`: pass raw cookie string directly. Auto-fetch only applies when `--auto-fetch-cookies` is enabled.
+- `--disable-browser-cookies`: use requests-based cookie mode.
+- `--auto-fetch-cookies`: auto-fetch cookies on startup (disabled by default).
+
+## MCP Client Config
+
+Claude Desktop:
+
+```json
+{
+  "mcpServers": {
+    "crawl4weibo": {
+      "command": "crawl4weibo-mcp",
+      "args": ["--auto-fetch-cookies"]
+    }
+  }
+}
+```
+
+Codex CLI (recommended `uv tool`):
+
+```bash
+uv tool install "crawl4weibo[mcp]"
+uv tool run --from "crawl4weibo[mcp]" python -m playwright install chromium
+codex mcp add crawl4weibo -- crawl4weibo-mcp --auto-fetch-cookies
+```
+
+Codex CLI (`uvx`, prewarm to avoid handshake timeout on first run):
+
+```bash
+uvx --from "crawl4weibo[mcp]" python -m playwright install chromium
+codex mcp add crawl4weibo -- uvx --from "crawl4weibo[mcp]" \
+  crawl4weibo-mcp --auto-fetch-cookies
+```

--- a/docs/MCP_zh.md
+++ b/docs/MCP_zh.md
@@ -1,0 +1,88 @@
+# MCP 服务器（供 Agent 调用）
+
+可将 crawl4weibo 作为 MCP 服务运行，供 LLM Agent 直接调用。
+
+## 环境要求
+
+- Python 3.10+
+- 在 Python 3.9 下，无论使用 `uv`、`uvx` 还是 `pip`，`crawl4weibo[mcp]` 额外依赖都不会生效。
+
+## 安装
+
+推荐（`uv`）：
+
+```bash
+uv tool install "crawl4weibo[mcp]"
+uv tool run --from "crawl4weibo[mcp]" python -m playwright install chromium
+```
+
+备选（`pip`）：
+
+```bash
+pip install "crawl4weibo[mcp]"
+python -m playwright install chromium
+```
+
+## 启动服务（stdio）
+
+```bash
+crawl4weibo-mcp
+```
+
+若命令不在 `PATH` 中：
+
+```bash
+uv tool run --from "crawl4weibo[mcp]" crawl4weibo-mcp
+```
+
+## 提供的工具
+
+- `get_user_by_uid`
+- `get_user_posts`
+- `get_post_by_bid`
+- `search_users`
+- `search_posts`
+- `get_comments`
+- `get_all_comments`
+
+## 响应详细级别
+
+- 默认：`detail_level="compact"`，返回更精简，节省上下文与 token。
+- 完整：`detail_level="full"`，返回完整字段（更接近原始 API 结构）。
+
+## CLI 参数
+
+- `--cookie`：直接传入原始 cookie 字符串。仅在启用 `--auto-fetch-cookies` 时才会自动抓取 cookie。
+- `--disable-browser-cookies`：禁用 Playwright，改用 requests 方式。
+- `--auto-fetch-cookies`：启动时自动抓取 cookie（默认关闭）。
+
+## MCP 客户端配置
+
+Claude Desktop：
+
+```json
+{
+  "mcpServers": {
+    "crawl4weibo": {
+      "command": "crawl4weibo-mcp",
+      "args": ["--auto-fetch-cookies"]
+    }
+  }
+}
+```
+
+Codex CLI（推荐 `uv tool`）：
+
+```bash
+uv tool install "crawl4weibo[mcp]"
+uv tool run --from "crawl4weibo[mcp]" python -m playwright install chromium
+codex mcp add crawl4weibo -- crawl4weibo-mcp --auto-fetch-cookies
+```
+
+Codex CLI（`uvx`，首次先预热，避免握手超时）：
+
+```bash
+uvx --from "crawl4weibo[mcp]" python -m playwright install chromium
+codex mcp add crawl4weibo -- uvx --from "crawl4weibo[mcp]" \
+  crawl4weibo-mcp --auto-fetch-cookies
+```


### PR DESCRIPTION
## Summary
- document Codex CLI MCP config commands
- include uv tool + uvx prewarm examples for Playwright

## Testing
- not run (docs-only change)
