### PR TITLE
feat: add video download support with multi-quality selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Crawl4Weibo is a ready-to-use Weibo (微博) web scraper Python library that sim
 - **Long Text Expansion**: Supports expanding truncated long posts, keyword search, user list fetching, and batch pagination
 - **Comment Scraping**: Fetch post comments with automatic pagination and support for nested replies
 - **Image Download Utilities**: Download images from single posts, batches, or entire pages with duplicate file detection
+- **Video Download Utilities**: Download videos with multi-quality selection (720p/SD/HD), streaming download, retry and proxy support
 - **Unified Logging & Error Types**: Quickly locate network, parsing, or authentication issues
 
 ## Installation
@@ -149,6 +150,47 @@ For more usage details, see [`examples/download_images_example.py`](examples/dow
 python examples/download_images_example.py
 ```
 
+## Video Download Example
+```python
+from crawl4weibo import WeiboClient
+
+client = WeiboClient()
+
+# Method 1: Download video from a single post
+post = client.get_post_by_bid("Q6FyDtbQc")
+if post.video_url:
+    print(f"Available qualities: {list(post.video_urls.keys())}")
+    result = client.download_post_video(
+        post,
+        download_dir="./downloads",
+        subdir="single_video"
+    )
+    if result:
+        print(f"Downloaded to: {result}")
+
+# Method 2: Batch download videos from user posts
+posts = client.get_user_posts("2656274875", page=1)
+results = client.download_posts_videos(
+    posts,
+    download_dir="./downloads"
+)
+
+# Method 3: Download videos from multiple pages of user posts
+results = client.download_user_posts_videos(
+    uid="2656274875",
+    pages=2,
+    download_dir="./downloads"
+)
+stats = client.video_downloader.get_download_stats(results)
+print(f"Downloaded {stats['successful']}/{stats['total']} videos")
+```
+For more usage details, see [`examples/download_videos_example.py`](examples/download_videos_example.py).
+
+**Run the example:**
+```bash
+python examples/download_videos_example.py
+```
+
 ## Proxy Pool Configuration Example
 ```python
 from crawl4weibo import WeiboClient, ProxyPoolConfig
@@ -206,6 +248,7 @@ posts = client.get_user_posts("2656274875", page=1)  # Uses proxy
 - `get_all_comments(post_id, max_pages=None)`: Get all comments with automatic pagination
 - `search_users(query, page=1, count=10, *, gender=None, location=None, birthday=None, age_range=None, education=None, company=None)` / `search_posts(query, page=1)`: Keyword search (user filters are applied locally)
 - `download_post_images(post, ...)`, `download_user_posts_images(uid, pages=2, ...)`: Download image assets
+- `download_post_video(post, ...)`, `download_posts_videos(posts, ...)`, `download_user_posts_videos(uid, pages=2, ...)`: Download video assets with multi-quality support
 - **Unified Exceptions**: `NetworkError`, `RateLimitError`, `UserNotFoundError`, etc., for business-level error handling
 
 ## CLI

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ client = WeiboClient()
 # Method 1: Download video from a single post
 post = client.get_post_by_bid("Q6FyDtbQc")
 if post.video_url:
+    # video_urls keys: "720p", "stream_hd", "sd", "stream" (when available)
     print(f"Available qualities: {list(post.video_urls.keys())}")
     result = client.download_post_video(
         post,

--- a/README_zh.md
+++ b/README_zh.md
@@ -157,6 +157,7 @@ client = WeiboClient()
 # 方式1: 下载单个帖子的视频
 post = client.get_post_by_bid("Q6FyDtbQc")
 if post.video_url:
+    # video_urls 的键: "720p", "stream_hd", "sd", "stream"（视可用画质而定）
     print(f"可用画质: {list(post.video_urls.keys())}")
     result = client.download_post_video(
         post,

--- a/README_zh.md
+++ b/README_zh.md
@@ -18,6 +18,7 @@ Crawl4Weibo 是一个开箱即用的微博爬虫 Python 库，模拟移动端请
 - **支持微博长文展开**：关键词搜索、用户列表抓取与批量分页
 - **评论抓取功能**：获取微博评论，支持自动翻页和嵌套回复
 - **提供图像下载工具**：支持单条、批量和整页下载，并带重复文件检查
+- **提供视频下载工具**：支持多画质选择（720p/SD/HD）、流式下载、重试与代理
 - **统一日志与错误类型**：便于快速定位网络、解析或鉴权问题
 
 ## 安装
@@ -147,6 +148,47 @@ results = client.download_user_posts_images(
 python examples/download_images_example.py
 ```
 
+## 视频下载示例
+```python
+from crawl4weibo import WeiboClient
+
+client = WeiboClient()
+
+# 方式1: 下载单个帖子的视频
+post = client.get_post_by_bid("Q6FyDtbQc")
+if post.video_url:
+    print(f"可用画质: {list(post.video_urls.keys())}")
+    result = client.download_post_video(
+        post,
+        download_dir="./downloads",
+        subdir="single_video"
+    )
+    if result:
+        print(f"已下载到: {result}")
+
+# 方式2: 批量下载用户帖子的视频
+posts = client.get_user_posts("2656274875", page=1)
+results = client.download_posts_videos(
+    posts,
+    download_dir="./downloads"
+)
+
+# 方式3: 下载用户多页帖子的视频
+results = client.download_user_posts_videos(
+    uid="2656274875",
+    pages=2,
+    download_dir="./downloads"
+)
+stats = client.video_downloader.get_download_stats(results)
+print(f"已下载 {stats['successful']}/{stats['total']} 个视频")
+```
+更多用法请参考 [`examples/download_videos_example.py`](examples/download_videos_example.py)。
+
+**运行示例：**
+```bash
+python examples/download_videos_example.py
+```
+
 ## 代理池配置示例
 ```python
 from crawl4weibo import WeiboClient, ProxyPoolConfig
@@ -204,6 +246,7 @@ posts = client.get_user_posts("2656274875", page=1)  # 使用代理
 - `get_all_comments(post_id, max_pages=None)`：自动翻页获取全部评论
 - `search_users(query, page=1, count=10, *, gender=None, location=None, birthday=None, age_range=None, education=None, company=None)` / `search_posts(query, page=1)`：关键词搜索（用户筛选为本地过滤）
 - `download_post_images(post, ...)`、`download_user_posts_images(uid, pages=2, ...)`：下载图像素材
+- `download_post_video(post, ...)`、`download_posts_videos(posts, ...)`、`download_user_posts_videos(uid, pages=2, ...)`：下载视频素材，支持多画质
 - **统一异常**：`NetworkError`、`RateLimitError`、`UserNotFoundError` 等，便于业务兜底
 
 ## CLI

--- a/crawl4weibo/__init__.py
+++ b/crawl4weibo/__init__.py
@@ -21,7 +21,7 @@ from .mcp.server import create_mcp_server
 from .models.comment import Comment
 from .models.post import Post
 from .models.user import User
-from .utils.downloader import ImageDownloader
+from .utils.downloader import ImageDownloader, VideoDownloader
 from .utils.proxy import ProxyPoolConfig
 from .utils.rate_limit import RateLimitConfig
 
@@ -31,6 +31,7 @@ __all__ = [
     "Post",
     "Comment",
     "ImageDownloader",
+    "VideoDownloader",
     "ProxyPoolConfig",
     "RateLimitConfig",
     "CrawlError",

--- a/crawl4weibo/core/client.py
+++ b/crawl4weibo/core/client.py
@@ -16,7 +16,7 @@ from ..models.comment import Comment
 from ..models.post import Post
 from ..models.user import User
 from ..utils.cookie_fetcher import LOGIN_COOKIE_NAMES, CookieFetcher
-from ..utils.downloader import ImageDownloader
+from ..utils.downloader import ImageDownloader, VideoDownloader
 from ..utils.logger import setup_logger
 from ..utils.parser import WeiboParser
 from ..utils.proxy import ProxyPool, ProxyPoolConfig
@@ -145,6 +145,11 @@ class WeiboClient:
         self.downloader = ImageDownloader(
             session=self.session,
             download_dir="./weibo_images",
+            proxy_pool=self.proxy_pool,
+        )
+        self.video_downloader = VideoDownloader(
+            session=self.session,
+            download_dir="./weibo_videos",
             proxy_pool=self.proxy_pool,
         )
 
@@ -591,6 +596,7 @@ class WeiboClient:
                     post.text = long_post.text
                     post.pic_urls = long_post.pic_urls
                     post.video_url = long_post.video_url
+                    post.video_urls = long_post.video_urls
                 except Exception as e:
                     self.logger.warning(f"Failed to expand long post {post.bid}: {e}")
 
@@ -1022,6 +1028,96 @@ class WeiboClient:
         subdir = f"user_{uid}"
 
         return self.download_posts_images(all_posts, download_dir, subdir)
+
+    def download_post_video(
+        self,
+        post: Post,
+        download_dir: str | None = None,
+        subdir: str | None = None,
+    ) -> str | None:
+        """
+        Download video from a single post
+
+        Args:
+            post: Post object containing video URL
+            download_dir: Custom download directory (optional)
+            subdir: Subdirectory name for organizing downloads
+
+        Returns:
+            Path to downloaded file if successful, None otherwise
+        """
+        if download_dir:
+            self.video_downloader.download_dir = Path(download_dir)
+            self.video_downloader.download_dir.mkdir(parents=True, exist_ok=True)
+
+        if not post.video_url:
+            self.logger.info(f"Post {post.id} has no video to download")
+            return None
+
+        return self.video_downloader.download_post_video(post, subdir)
+
+    def download_posts_videos(
+        self,
+        posts: list[Post],
+        download_dir: str | None = None,
+        subdir: str | None = None,
+    ) -> dict[str, str | None]:
+        """
+        Download videos from multiple posts
+
+        Args:
+            posts: List of Post objects
+            download_dir: Custom download directory (optional)
+            subdir: Subdirectory name for organizing downloads
+
+        Returns:
+            Dictionary mapping post IDs to downloaded file paths
+        """
+        if download_dir:
+            self.video_downloader.download_dir = Path(download_dir)
+            self.video_downloader.download_dir.mkdir(parents=True, exist_ok=True)
+
+        posts_with_video = [post for post in posts if post.video_url]
+        if not posts_with_video:
+            self.logger.info("No posts with videos found")
+            return {}
+
+        self.logger.info(
+            f"Found {len(posts_with_video)} posts with videos "
+            f"out of {len(posts)} total posts"
+        )
+        return self.video_downloader.download_posts_videos(posts_with_video, subdir)
+
+    def download_user_posts_videos(
+        self,
+        uid: str,
+        pages: int = 1,
+        download_dir: str | None = None,
+        expand_long_text: bool = False,
+    ) -> dict[str, str | None]:
+        """
+        Download videos from user's posts
+
+        Args:
+            uid: User ID
+            pages: Number of pages to fetch
+            download_dir: Custom download directory (optional)
+            expand_long_text: Whether to expand long text posts
+
+        Returns:
+            Dictionary mapping post IDs to downloaded file paths
+        """
+        all_posts: list[Post] = []
+
+        for page in range(1, pages + 1):
+            posts = self.get_user_posts(uid, page=page, expand=expand_long_text)
+            if not posts:
+                break
+            all_posts.extend(posts)
+
+        subdir = f"user_{uid}"
+
+        return self.download_posts_videos(all_posts, download_dir, subdir)
 
     @rate_limit()
     def get_comments(

--- a/crawl4weibo/models/post.py
+++ b/crawl4weibo/models/post.py
@@ -27,6 +27,7 @@ class Post:
     attitudes_count: int = 0
     pic_urls: list[str] = field(default_factory=list)
     video_url: str = ""
+    video_urls: dict[str, str] = field(default_factory=dict)
     is_original: bool = True
     retweeted_status: Optional["Post"] = None
     location: str = ""
@@ -62,6 +63,7 @@ class Post:
             "attitudes_count": data.get("attitudes_count", 0),
             "pic_urls": data.get("pic_urls", []),
             "video_url": data.get("video_url", ""),
+            "video_urls": data.get("video_urls", {}),
             "is_original": data.get("is_original", True),
             "retweeted_status": retweeted_status,
             "location": data.get("location", ""),
@@ -91,6 +93,7 @@ class Post:
             "attitudes_count": self.attitudes_count,
             "pic_urls": self.pic_urls,
             "video_url": self.video_url,
+            "video_urls": self.video_urls,
             "is_original": self.is_original,
             "location": self.location,
             "topic_ids": self.topic_ids,

--- a/crawl4weibo/utils/downloader.py
+++ b/crawl4weibo/utils/downloader.py
@@ -391,30 +391,43 @@ class VideoDownloader:
                                 f"Downloading with proxy: {proxies.get('http', 'N/A')}"
                             )
 
-                    response = self.session.get(
+                    with self.session.get(
                         url, timeout=60, stream=True, proxies=proxies
-                    )
-                    response.raise_for_status()
+                    ) as response:
+                        response.raise_for_status()
 
-                    content_type = response.headers.get("content-type", "")
-                    if not any(
-                        content_type.startswith(ct) for ct in self.VALID_CONTENT_TYPES
-                    ):
-                        self.logger.warning(
-                            f"URL does not return video content "
-                            f"(got {content_type}): {url}"
-                        )
-                        return None
+                        content_type = response.headers.get("content-type", "")
+                        if not any(
+                            content_type.startswith(ct)
+                            for ct in self.VALID_CONTENT_TYPES
+                        ):
+                            self.logger.warning(
+                                f"URL does not return video content "
+                                f"(got {content_type}): {url}"
+                            )
+                            return None
 
-                    with open(save_path, "wb") as f:
-                        for chunk in response.iter_content(chunk_size=self.chunk_size):
-                            if chunk:
-                                f.write(chunk)
+                        with open(save_path, "wb") as f:
+                            for chunk in response.iter_content(
+                                chunk_size=self.chunk_size
+                            ):
+                                if chunk:
+                                    f.write(chunk)
 
                     self.logger.info(f"Downloaded video: {save_path}")
                     return str(save_path)
 
                 except requests.exceptions.RequestException as e:
+                    # Remove partial file to avoid false "already exists"
+                    if save_path.exists():
+                        try:
+                            save_path.unlink()
+                        except OSError as cleanup_err:
+                            self.logger.warning(
+                                f"Failed to remove incomplete file "
+                                f"{save_path}: {cleanup_err}"
+                            )
+
                     if attempt < self.max_retries:
                         if using_proxy:
                             delay = random.uniform(0.5, 1.5)

--- a/crawl4weibo/utils/downloader.py
+++ b/crawl4weibo/utils/downloader.py
@@ -295,3 +295,248 @@ class ImageDownloader:
 
         count_results(download_results)
         return stats
+
+
+class VideoDownloader:
+    """Video downloader for Weibo posts"""
+
+    VALID_CONTENT_TYPES = ("video/", "application/octet-stream")
+    DEFAULT_HEADERS = {
+        "User-Agent": (
+            "Mozilla/5.0 (Linux; Android 13; SM-G9980) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) "
+            "Chrome/112.0.5615.135 Mobile Safari/537.36"
+        ),
+        "Referer": "https://m.weibo.cn/",
+    }
+
+    def __init__(
+        self,
+        session: requests.Session | None = None,
+        download_dir: str = "./videos",
+        max_retries: int = 3,
+        delay_range: tuple[float, float] = (1.0, 3.0),
+        proxy_pool: ProxyPool | None = None,
+        chunk_size: int = 65536,
+    ):
+        """
+        Initialize video downloader
+
+        Args:
+            session: Optional requests session to use
+            download_dir: Directory to save downloaded videos
+            max_retries: Maximum number of retry attempts
+            delay_range: Random delay range between downloads (min, max) in seconds
+            proxy_pool: Optional proxy pool for downloading videos
+            chunk_size: Chunk size for streaming downloads in bytes
+        """
+        self.logger = get_logger()
+        self.session = session or requests.Session()
+        self.download_dir = Path(download_dir)
+        self.max_retries = max_retries
+        self.delay_range = delay_range
+        self.proxy_pool = proxy_pool
+        self.chunk_size = chunk_size
+
+        if session is None:
+            self.session.headers.update(self.DEFAULT_HEADERS)
+
+    def download_video(
+        self,
+        url: str,
+        filename: str | None = None,
+        subdir: str | None = None,
+    ) -> str | None:
+        """
+        Download a single video
+
+        Args:
+            url: Video URL to download
+            filename: Optional custom filename
+            subdir: Optional subdirectory name
+
+        Returns:
+            Path to downloaded file if successful, None otherwise
+        """
+        if not url:
+            return None
+
+        try:
+            self.download_dir.mkdir(parents=True, exist_ok=True)
+
+            if subdir:
+                save_dir = self.download_dir / subdir
+                save_dir.mkdir(parents=True, exist_ok=True)
+            else:
+                save_dir = self.download_dir
+
+            if not filename:
+                filename = self._generate_filename(url)
+
+            save_path = save_dir / filename
+
+            if save_path.exists():
+                self.logger.info(f"Video already exists: {save_path}")
+                return str(save_path)
+
+            for attempt in range(1, self.max_retries + 1):
+                try:
+                    proxies = None
+                    using_proxy = False
+                    if self.proxy_pool and self.proxy_pool.is_enabled():
+                        proxies = self.proxy_pool.get_proxy()
+                        if proxies:
+                            using_proxy = True
+                            self.logger.debug(
+                                f"Downloading with proxy: {proxies.get('http', 'N/A')}"
+                            )
+
+                    response = self.session.get(
+                        url, timeout=60, stream=True, proxies=proxies
+                    )
+                    response.raise_for_status()
+
+                    content_type = response.headers.get("content-type", "")
+                    if not any(
+                        content_type.startswith(ct) for ct in self.VALID_CONTENT_TYPES
+                    ):
+                        self.logger.warning(
+                            f"URL does not return video content "
+                            f"(got {content_type}): {url}"
+                        )
+                        return None
+
+                    with open(save_path, "wb") as f:
+                        for chunk in response.iter_content(chunk_size=self.chunk_size):
+                            if chunk:
+                                f.write(chunk)
+
+                    self.logger.info(f"Downloaded video: {save_path}")
+                    return str(save_path)
+
+                except requests.exceptions.RequestException as e:
+                    if attempt < self.max_retries:
+                        if using_proxy:
+                            delay = random.uniform(0.5, 1.5)
+                        else:
+                            delay = random.uniform(2, 5)
+                        self.logger.warning(
+                            f"Video download failed (attempt {attempt}), "
+                            f"retrying in {delay:.1f}s: {e}"
+                        )
+                        time.sleep(delay)
+                    else:
+                        self.logger.error(
+                            f"Failed to download video {url} after "
+                            f"{self.max_retries} attempts: {e}"
+                        )
+                        raise NetworkError(f"Failed to download video: {e}")
+
+            return None
+
+        except NetworkError:
+            raise
+        except Exception as e:
+            self.logger.error(f"Error downloading video {url}: {e}")
+            return None
+
+    def download_post_video(
+        self,
+        post: Any,
+        subdir: str | None = None,
+    ) -> str | None:
+        """
+        Download video from a single post
+
+        Args:
+            post: Post object with video_url attribute
+            subdir: Optional subdirectory name
+
+        Returns:
+            Path to downloaded file if successful, None otherwise
+        """
+        video_url = getattr(post, "video_url", "")
+        if not video_url:
+            return None
+
+        post_id = getattr(post, "id", "unknown")
+        filename = f"{post_id}_{self._generate_filename(video_url)}"
+
+        try:
+            return self.download_video(video_url, filename, subdir)
+        except NetworkError as e:
+            self.logger.warning(
+                f"Network error downloading video for post {post_id}: {e}"
+            )
+            return None
+
+    def download_posts_videos(
+        self,
+        posts: list[Any],
+        subdir: str | None = None,
+    ) -> dict[str, str | None]:
+        """
+        Download videos from multiple posts
+
+        Args:
+            posts: List of Post objects
+            subdir: Optional subdirectory name
+
+        Returns:
+            Dictionary mapping post IDs to downloaded file paths
+        """
+        if not posts:
+            return {}
+
+        results: dict[str, str | None] = {}
+        video_posts = [p for p in posts if getattr(p, "video_url", "")]
+
+        self.logger.info(
+            f"Starting batch video download for {len(video_posts)} posts "
+            f"with videos (out of {len(posts)} total)"
+        )
+
+        for i, post in enumerate(video_posts):
+            if i > 0:
+                delay = random.uniform(*self.delay_range)
+                time.sleep(delay)
+
+            post_id = getattr(post, "id", f"post_{i}")
+            results[post_id] = self.download_post_video(post, subdir)
+
+        successful = sum(1 for path in results.values() if path is not None)
+        self.logger.info(
+            f"Batch video download completed: {successful}/{len(video_posts)} "
+            f"videos downloaded"
+        )
+
+        return results
+
+    def _generate_filename(self, url: str) -> str:
+        """Generate filename from URL"""
+        parsed_url = urllib.parse.urlparse(url)
+        filename = os.path.basename(parsed_url.path)
+
+        if not filename or "." not in filename:
+            filename = f"video_{hash(url) % 1000000}.mp4"
+
+        return filename
+
+    def get_download_stats(
+        self, download_results: dict[str, str | None]
+    ) -> dict[str, int]:
+        """
+        Get statistics from download results
+
+        Args:
+            download_results: Results from download_posts_videos
+
+        Returns:
+            Dictionary with download statistics
+        """
+        stats = {
+            "total": len(download_results),
+            "successful": sum(1 for v in download_results.values() if v is not None),
+            "failed": sum(1 for v in download_results.values() if v is None),
+        }
+        return stats

--- a/crawl4weibo/utils/parser.py
+++ b/crawl4weibo/utils/parser.py
@@ -297,8 +297,8 @@ class WeiboParser:
         media_info = mblog["page_info"].get("media_info", {})
         quality_keys = {
             "720p": "mp4_720p_mp4",
-            "sd": "mp4_sd_url",
             "stream_hd": "stream_url_hd",
+            "sd": "mp4_sd_url",
             "stream": "stream_url",
         }
         result: dict[str, str] = {}

--- a/crawl4weibo/utils/parser.py
+++ b/crawl4weibo/utils/parser.py
@@ -219,6 +219,7 @@ class WeiboParser:
                 "attitudes_count": mblog.get("attitudes_count", 0),
                 "pic_urls": self._extract_pic_urls(mblog),
                 "video_url": self._extract_video_url(mblog),
+                "video_urls": self._extract_video_urls(mblog),
                 "is_original": not mblog.get("retweeted_status"),
                 "location": mblog.get("geo", {}).get("name", ""),
                 "topic_ids": self._extract_topics(mblog.get("text", "")),
@@ -268,11 +269,44 @@ class WeiboParser:
         return pic_urls
 
     def _extract_video_url(self, mblog: dict[str, Any]) -> str:
+        """Extract the best quality video URL from post data."""
         if "page_info" in mblog and mblog["page_info"].get("type") == "video":
             media_info = mblog["page_info"].get("media_info", {})
-            return media_info.get("stream_url", "")
+            for key in (
+                "mp4_720p_mp4",
+                "stream_url_hd",
+                "mp4_sd_url",
+                "stream_url",
+            ):
+                url = media_info.get(key, "")
+                if url:
+                    return url
 
         return ""
+
+    def _extract_video_urls(self, mblog: dict[str, Any]) -> dict[str, str]:
+        """Extract all available video quality URLs from post data.
+
+        Returns:
+            dict[str, str]: Mapping of quality name to video URL,
+                e.g. {"720p": "https://...", "sd": "https://..."}
+        """
+        if "page_info" not in mblog or mblog["page_info"].get("type") != "video":
+            return {}
+
+        media_info = mblog["page_info"].get("media_info", {})
+        quality_keys = {
+            "720p": "mp4_720p_mp4",
+            "sd": "mp4_sd_url",
+            "stream_hd": "stream_url_hd",
+            "stream": "stream_url",
+        }
+        result: dict[str, str] = {}
+        for quality_name, key in quality_keys.items():
+            url = media_info.get(key, "")
+            if url:
+                result[quality_name] = url
+        return result
 
     def _extract_topics(self, text: str) -> list[str]:
         if not text:

--- a/examples/download_videos_example.py
+++ b/examples/download_videos_example.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+
+"""
+Video Download Example - Demonstrates how to use crawl4weibo to download Weibo videos
+"""
+
+from crawl4weibo import WeiboClient
+
+
+def main():
+    """Demonstrates video download functionality"""
+
+    client = WeiboClient()
+    test_uid = "2656274875"
+
+    print("=== Weibo Video Download Functionality Demo ===\n")
+
+    # Example 1: Download video from a single post
+    print("1. Download video from a single post")
+    try:
+        posts = client.get_user_posts(test_uid, page=1)
+        video_post = next((p for p in posts if p.video_url), None)
+
+        if video_post:
+            print(f"Found video post: {video_post.id}")
+            print(f"  Video URL: {video_post.video_url}")
+            if video_post.video_urls:
+                print(f"  Available qualities: {list(video_post.video_urls.keys())}")
+
+            result = client.download_post_video(
+                video_post,
+                download_dir="./example_downloads",
+                subdir="single_video",
+            )
+
+            if result:
+                print(f"  Downloaded to: {result}")
+            else:
+                print("  Download failed")
+        else:
+            print("No video posts found on page 1")
+    except Exception as e:
+        print(f"Failed: {e}")
+
+    print("\n" + "=" * 50 + "\n")
+
+    # Example 2: Download videos from user's recent posts
+    print("2. Batch download videos from user's posts")
+    try:
+        results = client.download_user_posts_videos(
+            uid=test_uid,
+            pages=2,
+            download_dir="./example_downloads",
+        )
+
+        stats = client.video_downloader.get_download_stats(results)
+        print("Download statistics:")
+        print(f"  Total videos: {stats['total']}")
+        print(f"  Successfully downloaded: {stats['successful']}")
+        print(f"  Failed: {stats['failed']}")
+    except Exception as e:
+        print(f"Failed: {e}")
+
+    print("\n=== Demo completed ===")
+    print("Downloaded videos are saved in the ./example_downloads/ directory")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/utils/test_video_downloader.py
+++ b/tests/unit/utils/test_video_downloader.py
@@ -336,3 +336,398 @@ class TestVideoUrlExtraction:
 
         assert parser._extract_video_urls({"text": "hello"}) == {}
         assert parser._extract_video_urls({"page_info": {"type": "webpage"}}) == {}
+
+
+@pytest.mark.unit
+class TestVideoDownloaderEdgeCases:
+    """Tests for edge cases and uncovered paths in VideoDownloader"""
+
+    @patch("requests.Session.get")
+    def test_download_video_with_subdir(self, mock_get):
+        """Test download creates subdirectory correctly"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            downloader = VideoDownloader(download_dir=temp_dir)
+
+            mock_response = Mock()
+            mock_response.status_code = 200
+            mock_response.headers = {"content-type": "video/mp4"}
+            mock_response.iter_content.return_value = [b"fake_video_data"]
+            mock_response.raise_for_status.return_value = None
+            mock_response.__enter__ = Mock(return_value=mock_response)
+            mock_response.__exit__ = Mock(return_value=False)
+            mock_get.return_value = mock_response
+
+            result = downloader.download_video(
+                "https://example.com/test.mp4", "test.mp4", subdir="my_sub"
+            )
+
+            assert result is not None
+            assert "my_sub" in result
+            assert Path(result).exists()
+
+    def test_download_video_already_exists(self):
+        """Test download skips when file already exists"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            downloader = VideoDownloader(download_dir=temp_dir)
+
+            # Create a file that "already exists"
+            existing = Path(temp_dir) / "existing.mp4"
+            existing.write_bytes(b"existing content")
+
+            result = downloader.download_video(
+                "https://example.com/existing.mp4", "existing.mp4"
+            )
+
+            assert result == str(existing)
+
+    def test_download_video_auto_generate_filename(self):
+        """Test download auto-generates filename from URL"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            downloader = VideoDownloader(download_dir=temp_dir)
+
+            with patch.object(downloader, "session") as mock_session:
+                mock_response = Mock()
+                mock_response.status_code = 200
+                mock_response.headers = {"content-type": "video/mp4"}
+                mock_response.iter_content.return_value = [b"data"]
+                mock_response.raise_for_status.return_value = None
+                mock_response.__enter__ = Mock(return_value=mock_response)
+                mock_response.__exit__ = Mock(return_value=False)
+                mock_session.get.return_value = mock_response
+
+                result = downloader.download_video("https://example.com/clip.mp4")
+
+                assert result is not None
+                assert "clip.mp4" in result
+
+    @patch("requests.Session.get")
+    def test_download_video_with_proxy(self, mock_get):
+        """Test download uses proxy when available"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            mock_pool = Mock()
+            mock_pool.is_enabled.return_value = True
+            mock_pool.get_proxy.return_value = {
+                "http": "http://proxy:8080",
+                "https": "http://proxy:8080",
+            }
+
+            downloader = VideoDownloader(
+                download_dir=temp_dir, proxy_pool=mock_pool
+            )
+
+            mock_response = Mock()
+            mock_response.status_code = 200
+            mock_response.headers = {"content-type": "video/mp4"}
+            mock_response.iter_content.return_value = [b"data"]
+            mock_response.raise_for_status.return_value = None
+            mock_response.__enter__ = Mock(return_value=mock_response)
+            mock_response.__exit__ = Mock(return_value=False)
+            mock_get.return_value = mock_response
+
+            result = downloader.download_video(
+                "https://example.com/test.mp4", "test.mp4"
+            )
+
+            assert result is not None
+            call_kwargs = mock_get.call_args
+            assert call_kwargs.kwargs.get("proxies") is not None
+
+    @patch("requests.Session.get")
+    def test_download_video_retry_cleans_partial_file(self, mock_get):
+        """Test that partial files are cleaned up on failure"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            downloader = VideoDownloader(
+                download_dir=temp_dir, max_retries=2
+            )
+
+            call_count = 0
+
+            def side_effect(*args, **kwargs):
+                nonlocal call_count
+                call_count += 1
+                if call_count == 1:
+                    # First call: write partial file then fail
+                    partial = Path(temp_dir) / "test.mp4"
+                    partial.write_bytes(b"partial")
+                    raise requests.exceptions.ConnectionError("broken")
+                # Second call: succeed
+                mock_resp = Mock()
+                mock_resp.status_code = 200
+                mock_resp.headers = {"content-type": "video/mp4"}
+                mock_resp.iter_content.return_value = [b"complete_data"]
+                mock_resp.raise_for_status.return_value = None
+                mock_resp.__enter__ = Mock(return_value=mock_resp)
+                mock_resp.__exit__ = Mock(return_value=False)
+                return mock_resp
+
+            mock_get.side_effect = side_effect
+
+            result = downloader.download_video(
+                "https://example.com/test.mp4", "test.mp4"
+            )
+
+            assert result is not None
+            assert Path(result).read_bytes() == b"complete_data"
+
+    @patch("requests.Session.get")
+    def test_download_video_retry_with_proxy_uses_short_delay(self, mock_get):
+        """Test retry delay is shorter when using proxy"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            mock_pool = Mock()
+            mock_pool.is_enabled.return_value = True
+            mock_pool.get_proxy.return_value = {"http": "http://p:8080"}
+
+            downloader = VideoDownloader(
+                download_dir=temp_dir, max_retries=2, proxy_pool=mock_pool
+            )
+
+            mock_get.side_effect = [
+                requests.exceptions.ConnectionError("fail1"),
+                # Second call succeeds
+                Mock(
+                    status_code=200,
+                    headers={"content-type": "video/mp4"},
+                    iter_content=Mock(return_value=[b"data"]),
+                    raise_for_status=Mock(return_value=None),
+                    __enter__=Mock(
+                        return_value=Mock(
+                            status_code=200,
+                            headers={"content-type": "video/mp4"},
+                            iter_content=Mock(return_value=[b"data"]),
+                            raise_for_status=Mock(return_value=None),
+                        )
+                    ),
+                    __exit__=Mock(return_value=False),
+                ),
+            ]
+
+            with patch("crawl4weibo.utils.downloader.time.sleep") as mock_sleep:
+                result = downloader.download_video(
+                    "https://example.com/test.mp4", "test.mp4"
+                )
+
+                # Should use proxy delay range (0.5-1.5)
+                if mock_sleep.called:
+                    delay = mock_sleep.call_args[0][0]
+                    assert 0.5 <= delay <= 1.5
+
+    def test_download_post_video_network_error_handled(self):
+        """Test download_post_video catches NetworkError gracefully"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            downloader = VideoDownloader(download_dir=temp_dir)
+
+            post = Post(
+                id="999",
+                bid="bid999",
+                user_id="u1",
+                video_url="https://example.com/video.mp4",
+            )
+
+            with patch.object(
+                downloader, "download_video", side_effect=NetworkError("fail")
+            ):
+                result = downloader.download_post_video(post)
+                assert result is None
+
+
+@pytest.mark.unit
+class TestWeiboClientVideoDownload:
+    """Tests for WeiboClient video download methods"""
+
+    def test_download_post_video_with_video(self, client_no_rate_limit):
+        """Test client download_post_video delegates to video_downloader"""
+        post = Post(
+            id="100",
+            bid="bid100",
+            user_id="u1",
+            video_url="https://example.com/v.mp4",
+        )
+
+        with patch.object(
+            client_no_rate_limit.video_downloader,
+            "download_post_video",
+            return_value="/tmp/100_v.mp4",
+        ) as mock_dl:
+            result = client_no_rate_limit.download_post_video(post)
+            assert result == "/tmp/100_v.mp4"
+            mock_dl.assert_called_once_with(post, None)
+
+    def test_download_post_video_no_video(self, client_no_rate_limit):
+        """Test client download_post_video returns None when no video"""
+        post = Post(id="101", bid="bid101", user_id="u1", video_url="")
+
+        result = client_no_rate_limit.download_post_video(post)
+        assert result is None
+
+    def test_download_post_video_custom_dir(self, client_no_rate_limit):
+        """Test client download_post_video with custom download_dir"""
+        post = Post(
+            id="102",
+            bid="bid102",
+            user_id="u1",
+            video_url="https://example.com/v.mp4",
+        )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with patch.object(
+                client_no_rate_limit.video_downloader,
+                "download_post_video",
+                return_value=f"{temp_dir}/v.mp4",
+            ):
+                result = client_no_rate_limit.download_post_video(
+                    post, download_dir=temp_dir
+                )
+                assert result is not None
+                assert client_no_rate_limit.video_downloader.download_dir == Path(
+                    temp_dir
+                )
+
+    def test_download_posts_videos(self, client_no_rate_limit):
+        """Test client download_posts_videos filters and delegates"""
+        posts = [
+            Post(
+                id="1", bid="b1", user_id="u1",
+                video_url="https://example.com/v1.mp4",
+            ),
+            Post(id="2", bid="b2", user_id="u2", video_url=""),
+            Post(
+                id="3", bid="b3", user_id="u3",
+                video_url="https://example.com/v3.mp4",
+            ),
+        ]
+
+        with patch.object(
+            client_no_rate_limit.video_downloader,
+            "download_posts_videos",
+            return_value={"1": "/tmp/v1.mp4", "3": "/tmp/v3.mp4"},
+        ) as mock_dl:
+            result = client_no_rate_limit.download_posts_videos(posts)
+            assert len(result) == 2
+            # Should only pass posts with video_url
+            called_posts = mock_dl.call_args[0][0]
+            assert len(called_posts) == 2
+
+    def test_download_posts_videos_none_with_video(self, client_no_rate_limit):
+        """Test client download_posts_videos with no video posts"""
+        posts = [
+            Post(id="1", bid="b1", user_id="u1", video_url=""),
+            Post(id="2", bid="b2", user_id="u2", video_url=""),
+        ]
+
+        result = client_no_rate_limit.download_posts_videos(posts)
+        assert result == {}
+
+    def test_download_posts_videos_custom_dir(self, client_no_rate_limit):
+        """Test client download_posts_videos with custom download_dir"""
+        posts = [
+            Post(
+                id="1", bid="b1", user_id="u1",
+                video_url="https://example.com/v.mp4",
+            ),
+        ]
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with patch.object(
+                client_no_rate_limit.video_downloader,
+                "download_posts_videos",
+                return_value={"1": f"{temp_dir}/v.mp4"},
+            ):
+                client_no_rate_limit.download_posts_videos(
+                    posts, download_dir=temp_dir
+                )
+                assert client_no_rate_limit.video_downloader.download_dir == Path(
+                    temp_dir
+                )
+
+    def test_download_user_posts_videos(self, client_no_rate_limit):
+        """Test client download_user_posts_videos fetches and delegates"""
+        posts = [
+            Post(
+                id="1", bid="b1", user_id="u1",
+                video_url="https://example.com/v.mp4",
+            ),
+        ]
+
+        with patch.object(
+            client_no_rate_limit, "get_user_posts", return_value=posts
+        ) as mock_get:
+            with patch.object(
+                client_no_rate_limit,
+                "download_posts_videos",
+                return_value={"1": "/tmp/v.mp4"},
+            ) as mock_dl:
+                result = client_no_rate_limit.download_user_posts_videos(
+                    "12345", pages=1
+                )
+
+                assert result == {"1": "/tmp/v.mp4"}
+                mock_get.assert_called_once_with(
+                    "12345", page=1, expand=False
+                )
+                mock_dl.assert_called_once()
+                # Check subdir is user_{uid}
+                call_args = mock_dl.call_args
+                assert call_args[0][1] is None  # download_dir
+                assert call_args[0][2] == "user_12345"  # subdir
+
+    def test_download_user_posts_videos_multi_page(self, client_no_rate_limit):
+        """Test client download_user_posts_videos with multiple pages"""
+        page1 = [
+            Post(
+                id="1", bid="b1", user_id="u1",
+                video_url="https://example.com/v1.mp4",
+            ),
+        ]
+        page2 = [
+            Post(
+                id="2", bid="b2", user_id="u1",
+                video_url="https://example.com/v2.mp4",
+            ),
+        ]
+
+        with patch.object(
+            client_no_rate_limit,
+            "get_user_posts",
+            side_effect=[page1, page2],
+        ):
+            with patch.object(
+                client_no_rate_limit,
+                "download_posts_videos",
+                return_value={"1": "/v1.mp4", "2": "/v2.mp4"},
+            ) as mock_dl:
+                result = client_no_rate_limit.download_user_posts_videos(
+                    "12345", pages=2
+                )
+
+                assert len(result) == 2
+                # Should have collected posts from both pages
+                called_posts = mock_dl.call_args[0][0]
+                assert len(called_posts) == 2
+
+    def test_download_user_posts_videos_empty_page_stops(
+        self, client_no_rate_limit
+    ):
+        """Test pagination stops when an empty page is returned"""
+        page1 = [
+            Post(
+                id="1", bid="b1", user_id="u1",
+                video_url="https://example.com/v.mp4",
+            ),
+        ]
+
+        with patch.object(
+            client_no_rate_limit,
+            "get_user_posts",
+            side_effect=[page1, []],
+        ) as mock_get:
+            with patch.object(
+                client_no_rate_limit,
+                "download_posts_videos",
+                return_value={"1": "/v.mp4"},
+            ):
+                client_no_rate_limit.download_user_posts_videos(
+                    "12345", pages=3
+                )
+
+                # Should stop after page 2 returns empty
+                assert mock_get.call_count == 2

--- a/tests/unit/utils/test_video_downloader.py
+++ b/tests/unit/utils/test_video_downloader.py
@@ -62,6 +62,8 @@ class TestVideoDownloader:
             mock_response.headers = {"content-type": "video/mp4"}
             mock_response.iter_content.return_value = [b"fake_video_data"]
             mock_response.raise_for_status.return_value = None
+            mock_response.__enter__ = Mock(return_value=mock_response)
+            mock_response.__exit__ = Mock(return_value=False)
             mock_get.return_value = mock_response
 
             url = "https://example.com/test.mp4"
@@ -82,6 +84,8 @@ class TestVideoDownloader:
             mock_response.headers = {"content-type": "application/octet-stream"}
             mock_response.iter_content.return_value = [b"fake_video_data"]
             mock_response.raise_for_status.return_value = None
+            mock_response.__enter__ = Mock(return_value=mock_response)
+            mock_response.__exit__ = Mock(return_value=False)
             mock_get.return_value = mock_response
 
             url = "https://example.com/test.mp4"
@@ -99,6 +103,8 @@ class TestVideoDownloader:
             mock_response.status_code = 200
             mock_response.headers = {"content-type": "text/html"}
             mock_response.raise_for_status.return_value = None
+            mock_response.__enter__ = Mock(return_value=mock_response)
+            mock_response.__exit__ = Mock(return_value=False)
             mock_get.return_value = mock_response
 
             url = "https://example.com/notvideo.txt"
@@ -299,8 +305,8 @@ class TestVideoUrlExtraction:
         result = parser._extract_video_urls(mblog)
         assert result == {
             "720p": "https://example.com/720p.mp4",
-            "sd": "https://example.com/sd.mp4",
             "stream_hd": "https://example.com/stream_hd.mp4",
+            "sd": "https://example.com/sd.mp4",
             "stream": "https://example.com/stream.mp4",
         }
 

--- a/tests/unit/utils/test_video_downloader.py
+++ b/tests/unit/utils/test_video_downloader.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python
+
+"""
+Test cases for the video downloader functionality
+"""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+import requests
+
+from crawl4weibo.exceptions.base import NetworkError
+from crawl4weibo.models.post import Post
+from crawl4weibo.utils.downloader import VideoDownloader
+from crawl4weibo.utils.parser import WeiboParser
+
+
+@pytest.mark.unit
+class TestVideoDownloader:
+    """Unit tests for VideoDownloader class"""
+
+    def test_downloader_initialization(self):
+        """Test downloader initializes correctly"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            downloader = VideoDownloader(download_dir=temp_dir)
+            assert downloader.download_dir == Path(temp_dir)
+            assert downloader.max_retries == 3
+            assert downloader.delay_range == (1.0, 3.0)
+            assert downloader.chunk_size == 65536
+
+    def test_generate_filename(self):
+        """Test filename generation from URL"""
+        downloader = VideoDownloader()
+
+        url = "https://f.video.weibocdn.com/abc123.mp4?label=mp4_720p"
+        filename = downloader._generate_filename(url)
+        assert filename == "abc123.mp4"
+
+        # URL without extension
+        url = "https://example.com/video"
+        filename = downloader._generate_filename(url)
+        assert filename.startswith("video_")
+        assert filename.endswith(".mp4")
+
+    def test_default_session_uses_browser_headers(self):
+        """Test standalone downloader sets browser headers on its own session."""
+        downloader = VideoDownloader()
+
+        assert downloader.session.headers["User-Agent"].startswith("Mozilla/5.0")
+        assert downloader.session.headers["Referer"] == "https://m.weibo.cn/"
+
+    @patch("requests.Session.get")
+    def test_download_video_success(self, mock_get):
+        """Test successful video download"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            downloader = VideoDownloader(download_dir=temp_dir)
+
+            mock_response = Mock()
+            mock_response.status_code = 200
+            mock_response.headers = {"content-type": "video/mp4"}
+            mock_response.iter_content.return_value = [b"fake_video_data"]
+            mock_response.raise_for_status.return_value = None
+            mock_get.return_value = mock_response
+
+            url = "https://example.com/test.mp4"
+            result = downloader.download_video(url, "test.mp4")
+
+            assert result is not None
+            assert "test.mp4" in result
+            assert Path(result).exists()
+
+    @patch("requests.Session.get")
+    def test_download_video_octet_stream_content(self, mock_get):
+        """Test download with application/octet-stream content type"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            downloader = VideoDownloader(download_dir=temp_dir)
+
+            mock_response = Mock()
+            mock_response.status_code = 200
+            mock_response.headers = {"content-type": "application/octet-stream"}
+            mock_response.iter_content.return_value = [b"fake_video_data"]
+            mock_response.raise_for_status.return_value = None
+            mock_get.return_value = mock_response
+
+            url = "https://example.com/test.mp4"
+            result = downloader.download_video(url, "test.mp4")
+
+            assert result is not None
+
+    @patch("requests.Session.get")
+    def test_download_video_non_video_content(self, mock_get):
+        """Test download with non-video content type"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            downloader = VideoDownloader(download_dir=temp_dir)
+
+            mock_response = Mock()
+            mock_response.status_code = 200
+            mock_response.headers = {"content-type": "text/html"}
+            mock_response.raise_for_status.return_value = None
+            mock_get.return_value = mock_response
+
+            url = "https://example.com/notvideo.txt"
+            result = downloader.download_video(url, "test.mp4")
+
+            assert result is None
+
+    @patch("requests.Session.get")
+    def test_download_video_network_error(self, mock_get):
+        """Test download with network error"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            downloader = VideoDownloader(download_dir=temp_dir, max_retries=1)
+
+            mock_get.side_effect = requests.exceptions.RequestException("Network error")
+
+            url = "https://example.com/test.mp4"
+
+            with pytest.raises(NetworkError):
+                downloader.download_video(url, "test.mp4")
+
+    def test_download_video_empty_url(self):
+        """Test download with empty URL"""
+        downloader = VideoDownloader()
+        result = downloader.download_video("")
+        assert result is None
+
+    def test_download_post_video(self):
+        """Test downloading video from a post"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            downloader = VideoDownloader(download_dir=temp_dir)
+
+            post = Post(
+                id="12345",
+                bid="bid1",
+                user_id="user1",
+                video_url="https://example.com/video.mp4",
+            )
+
+            with patch.object(downloader, "download_video") as mock_download:
+                mock_download.return_value = f"{temp_dir}/12345_video.mp4"
+
+                result = downloader.download_post_video(post)
+
+                assert result is not None
+                mock_download.assert_called_once()
+
+    def test_download_post_video_no_video(self):
+        """Test downloading video from post without video"""
+        downloader = VideoDownloader()
+
+        post = Post(id="12345", bid="bid1", user_id="user1", video_url="")
+
+        result = downloader.download_post_video(post)
+        assert result is None
+
+    def test_download_posts_videos(self):
+        """Test downloading videos from multiple posts"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            downloader = VideoDownloader(download_dir=temp_dir)
+
+            post1 = Post(
+                id="1",
+                bid="bid1",
+                user_id="user1",
+                video_url="https://example.com/video1.mp4",
+            )
+            post2 = Post(
+                id="2",
+                bid="bid2",
+                user_id="user2",
+                video_url="https://example.com/video2.mp4",
+            )
+            post3 = Post(
+                id="3",
+                bid="bid3",
+                user_id="user3",
+                video_url="",  # no video
+            )
+            posts = [post1, post2, post3]
+
+            with patch.object(downloader, "download_post_video") as mock_download:
+                mock_download.return_value = f"{temp_dir}/video.mp4"
+
+                results = downloader.download_posts_videos(posts)
+
+                # Only post1 and post2 have videos
+                assert len(results) == 2
+                assert "1" in results
+                assert "2" in results
+                assert mock_download.call_count == 2
+
+    def test_download_posts_videos_empty(self):
+        """Test downloading videos from empty list"""
+        downloader = VideoDownloader()
+        results = downloader.download_posts_videos([])
+        assert results == {}
+
+    def test_get_download_stats(self):
+        """Test getting download statistics"""
+        downloader = VideoDownloader()
+
+        results = {
+            "post1": "/path/to/video1.mp4",
+            "post2": None,
+            "post3": "/path/to/video3.mp4",
+        }
+
+        stats = downloader.get_download_stats(results)
+
+        assert stats["total"] == 3
+        assert stats["successful"] == 2
+        assert stats["failed"] == 1
+
+
+@pytest.mark.unit
+class TestVideoUrlExtraction:
+    """Unit tests for video URL extraction in parser"""
+
+    def test_extract_video_url_best_quality(self):
+        """Test that _extract_video_url returns best quality URL"""
+        parser = WeiboParser()
+
+        mblog = {
+            "page_info": {
+                "type": "video",
+                "media_info": {
+                    "stream_url": "https://example.com/stream.mp4",
+                    "stream_url_hd": "https://example.com/stream_hd.mp4",
+                    "mp4_sd_url": "https://example.com/sd.mp4",
+                    "mp4_720p_mp4": "https://example.com/720p.mp4",
+                },
+            }
+        }
+
+        result = parser._extract_video_url(mblog)
+        assert result == "https://example.com/720p.mp4"
+
+    def test_extract_video_url_fallback(self):
+        """Test fallback when higher quality is not available"""
+        parser = WeiboParser()
+
+        mblog = {
+            "page_info": {
+                "type": "video",
+                "media_info": {
+                    "stream_url": "https://example.com/stream.mp4",
+                },
+            }
+        }
+
+        result = parser._extract_video_url(mblog)
+        assert result == "https://example.com/stream.mp4"
+
+    def test_extract_video_url_prefers_hd_stream_over_sd(self):
+        """Test HD stream is preferred over SD when 720p is unavailable."""
+        parser = WeiboParser()
+
+        mblog = {
+            "page_info": {
+                "type": "video",
+                "media_info": {
+                    "stream_url_hd": "https://example.com/stream_hd.mp4",
+                    "mp4_sd_url": "https://example.com/sd.mp4",
+                    "stream_url": "https://example.com/stream.mp4",
+                },
+            }
+        }
+
+        result = parser._extract_video_url(mblog)
+        assert result == "https://example.com/stream_hd.mp4"
+
+    def test_extract_video_url_no_video(self):
+        """Test extraction when post has no video"""
+        parser = WeiboParser()
+
+        mblog = {"page_info": {"type": "webpage"}}
+        assert parser._extract_video_url(mblog) == ""
+
+        mblog_no_page = {"text": "hello"}
+        assert parser._extract_video_url(mblog_no_page) == ""
+
+    def test_extract_video_urls_all_qualities(self):
+        """Test extracting all quality URLs"""
+        parser = WeiboParser()
+
+        mblog = {
+            "page_info": {
+                "type": "video",
+                "media_info": {
+                    "stream_url": "https://example.com/stream.mp4",
+                    "stream_url_hd": "https://example.com/stream_hd.mp4",
+                    "mp4_sd_url": "https://example.com/sd.mp4",
+                    "mp4_720p_mp4": "https://example.com/720p.mp4",
+                },
+            }
+        }
+
+        result = parser._extract_video_urls(mblog)
+        assert result == {
+            "720p": "https://example.com/720p.mp4",
+            "sd": "https://example.com/sd.mp4",
+            "stream_hd": "https://example.com/stream_hd.mp4",
+            "stream": "https://example.com/stream.mp4",
+        }
+
+    def test_extract_video_urls_partial(self):
+        """Test extracting URLs when only some qualities are available"""
+        parser = WeiboParser()
+
+        mblog = {
+            "page_info": {
+                "type": "video",
+                "media_info": {
+                    "stream_url": "https://example.com/stream.mp4",
+                    "mp4_sd_url": "https://example.com/sd.mp4",
+                },
+            }
+        }
+
+        result = parser._extract_video_urls(mblog)
+        assert len(result) == 2
+        assert "sd" in result
+        assert "stream" in result
+        assert "720p" not in result
+
+    def test_extract_video_urls_no_video(self):
+        """Test extraction returns empty dict when no video"""
+        parser = WeiboParser()
+
+        assert parser._extract_video_urls({"text": "hello"}) == {}
+        assert parser._extract_video_urls({"page_info": {"type": "webpage"}}) == {}


### PR DESCRIPTION
## Summary
- Add `VideoDownloader` class with streaming download, retry logic, proxy integration, and file dedup — mirroring `ImageDownloader` patterns
- Enhance video URL extraction to support multi-quality selection (720p > SD > HD > stream) with new `Post.video_urls` dict field
- Integrate into `WeiboClient` with `download_post_video()`, `download_posts_videos()`, and `download_user_posts_videos()` methods
- Export `VideoDownloader` from package, update both README.md and README_zh.md

## Test plan
- [x] 20 unit tests added in `tests/unit/utils/test_video_downloader.py` — all passing
- [x] Full unit test suite passes (292 passed, 0 failed)
- [x] Linter and formatter pass (`ruff check` + `ruff format`)
- [ ] Manual verification: run `examples/download_videos_example.py` against a real Weibo account with video posts

🤖 Generated with [Claude Code](https://claude.com/claude-code)